### PR TITLE
Support year/month sales format with country/product filters

### DIFF
--- a/components/DataInput.tsx
+++ b/components/DataInput.tsx
@@ -1,5 +1,4 @@
-
-import React, { useState, ChangeEvent } from 'react';
+import React, { useState, ChangeEvent, useEffect } from 'react';
 import type { SalesData } from '../types';
 
 interface DataInputProps {
@@ -7,11 +6,9 @@ interface DataInputProps {
 }
 
 const DataInput: React.FC<DataInputProps> = ({ onDataLoaded }) => {
-  const [activeTab, setActiveTab] = useState<'csv' | 'manual'>('csv');
-  const [manualData, setManualData] = useState<Partial<SalesData>[]>([
-    { date: '2022-01-01', region: 'North', product: 'A', sales: 1000 },
-    { date: '2022-02-01', region: 'North', product: 'A', sales: 1100 },
-  ]);
+  const [originalData, setOriginalData] = useState<SalesData[]>([]);
+  const [countryFilter, setCountryFilter] = useState('All');
+  const [productFilter, setProductFilter] = useState('All');
   const [error, setError] = useState<string | null>(null);
 
   const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
@@ -25,22 +22,23 @@ const DataInput: React.FC<DataInputProps> = ({ onDataLoaded }) => {
       try {
         const rows = text.split('\n').filter(row => row.trim() !== '');
         const header = rows[0].split(',').map(h => h.trim());
-        const requiredHeaders = ['date', 'region', 'product', 'sales'];
-        if(!requiredHeaders.every(h => header.includes(h))) {
-            throw new Error('CSV must contain date, region, product, and sales columns.');
+        const requiredHeaders = ['year', 'month', 'sales', 'country', 'product'];
+        if (!requiredHeaders.every(h => header.includes(h))) {
+          throw new Error('CSV must contain year, month, sales, country, and product columns.');
         }
 
         const data: SalesData[] = rows.slice(1).map(row => {
           const values = row.split(',');
           return {
-            date: values[header.indexOf('date')].trim(),
-            region: values[header.indexOf('region')].trim(),
+            year: parseInt(values[header.indexOf('year')].trim(), 10),
+            month: parseInt(values[header.indexOf('month')].trim(), 10),
+            sales: parseFloat(values[header.indexOf('sales')].trim()),
+            country: values[header.indexOf('country')].trim(),
             product: values[header.indexOf('product')].trim(),
-            sales: parseFloat(values[header.indexOf('sales')].trim())
           };
-        }).filter(d => !isNaN(d.sales));
-        
-        onDataLoaded(data);
+        }).filter(d => !isNaN(d.sales) && !isNaN(d.year) && !isNaN(d.month));
+
+        setOriginalData(data);
       } catch (err) {
         setError('Failed to parse CSV file. Please check the format.');
         console.error(err);
@@ -48,44 +46,84 @@ const DataInput: React.FC<DataInputProps> = ({ onDataLoaded }) => {
     };
     reader.readAsText(file);
   };
-  
+
+  const countries = Array.from(new Set(originalData.map(d => d.country)));
+  const products = Array.from(new Set(originalData.map(d => d.product)));
+
+  useEffect(() => {
+    const filtered = originalData.filter(d =>
+      (countryFilter === 'All' || d.country === countryFilter) &&
+      (productFilter === 'All' || d.product === productFilter)
+    );
+    onDataLoaded(filtered);
+  }, [originalData, countryFilter, productFilter, onDataLoaded]);
+
+  const sampleData: SalesData[] = [
+    { year: 2022, month: 1, sales: 1500, country: 'North', product: 'Gadget' },
+    { year: 2022, month: 2, sales: 1650, country: 'North', product: 'Gadget' },
+    { year: 2022, month: 3, sales: 1800, country: 'North', product: 'Gadget' },
+    { year: 2022, month: 4, sales: 1750, country: 'North', product: 'Gadget' },
+    { year: 2022, month: 5, sales: 1900, country: 'North', product: 'Gadget' },
+    { year: 2022, month: 6, sales: 2100, country: 'North', product: 'Gadget' },
+    { year: 2022, month: 7, sales: 2050, country: 'North', product: 'Gadget' },
+    { year: 2022, month: 8, sales: 2200, country: 'North', product: 'Gadget' },
+    { year: 2022, month: 9, sales: 2300, country: 'North', product: 'Gadget' },
+    { year: 2022, month: 10, sales: 2500, country: 'North', product: 'Gadget' },
+    { year: 2022, month: 11, sales: 2800, country: 'North', product: 'Gadget' },
+    { year: 2022, month: 12, sales: 3200, country: 'North', product: 'Gadget' },
+    { year: 2023, month: 1, sales: 1800, country: 'North', product: 'Gadget' },
+    { year: 2023, month: 2, sales: 1950, country: 'North', product: 'Gadget' },
+    { year: 2023, month: 3, sales: 2100, country: 'North', product: 'Gadget' },
+    { year: 2023, month: 4, sales: 2050, country: 'North', product: 'Gadget' },
+  ];
+
   return (
     <div className="bg-dark-surface rounded-xl shadow-lg p-6">
       <h2 className="text-xl font-bold mb-4 text-dark-text-primary">1. Input Your Data</h2>
-      {/* Tabs would go here if needed, simplified for now */}
+
+      {originalData.length > 0 && (
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-4">
+          <div>
+            <label className="block text-sm font-medium text-dark-text-secondary mb-1">Country</label>
+            <select
+              value={countryFilter}
+              onChange={(e) => setCountryFilter(e.target.value)}
+              className="w-full bg-gray-700 border border-gray-600 rounded-lg p-2.5 text-dark-text-primary focus:ring-brand-primary focus:border-brand-primary"
+            >
+              <option value="All">All Countries</option>
+              {countries.map(c => <option key={c} value={c}>{c}</option>)}
+            </select>
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-dark-text-secondary mb-1">Product</label>
+            <select
+              value={productFilter}
+              onChange={(e) => setProductFilter(e.target.value)}
+              className="w-full bg-gray-700 border border-gray-600 rounded-lg p-2.5 text-dark-text-primary focus:ring-brand-primary focus:border-brand-primary"
+            >
+              <option value="All">All Products</option>
+              {products.map(p => <option key={p} value={p}>{p}</option>)}
+            </select>
+          </div>
+        </div>
+      )}
+
       <div>
         <h3 className="text-lg font-semibold mb-2 text-dark-text-secondary">Upload CSV</h3>
-        <p className="text-sm text-gray-400 mb-3">Must contain columns: date, region, product, sales.</p>
-        <input 
-          type="file" 
+        <p className="text-sm text-gray-400 mb-3">Must contain columns: year, month, sales, country, product.</p>
+        <input
+          type="file"
           accept=".csv"
           onChange={handleFileChange}
           className="block w-full text-sm text-gray-400 file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:font-semibold file:bg-brand-secondary file:text-brand-primary hover:file:bg-blue-200"
         />
         {error && <p className="text-red-400 text-sm mt-2">{error}</p>}
         <p className="text-center my-4 text-gray-500">OR</p>
-        <button 
-            onClick={() => onDataLoaded([
-                { date: '2022-01-01', region: 'North', product: 'Gadget', sales: 1500 },
-                { date: '2022-02-01', region: 'North', product: 'Gadget', sales: 1650 },
-                { date: '2022-03-01', region: 'North', product: 'Gadget', sales: 1800 },
-                { date: '2022-04-01', region: 'North', product: 'Gadget', sales: 1750 },
-                { date: '2022-05-01', region: 'North', product: 'Gadget', sales: 1900 },
-                { date: '2022-06-01', region: 'North', product: 'Gadget', sales: 2100 },
-                { date: '2022-07-01', region: 'North', product: 'Gadget', sales: 2050 },
-                { date: '2022-08-01', region: 'North', product: 'Gadget', sales: 2200 },
-                { date: '2022-09-01', region: 'North', product: 'Gadget', sales: 2300 },
-                { date: '2022-10-01', region: 'North', product: 'Gadget', sales: 2500 },
-                { date: '2022-11-01', region: 'North', product: 'Gadget', sales: 2800 },
-                { date: '2022-12-01', region: 'North', product: 'Gadget', sales: 3200 },
-                { date: '2023-01-01', region: 'North', product: 'Gadget', sales: 1800 },
-                { date: '2023-02-01', region: 'North', product: 'Gadget', sales: 1950 },
-                { date: '2023-03-01', region: 'North', product: 'Gadget', sales: 2100 },
-                { date: '2023-04-01', region: 'North', product: 'Gadget', sales: 2050 },
-            ])}
-            className="w-full bg-gray-600 text-white font-bold py-2 px-4 rounded-lg hover:bg-gray-700 transition duration-300"
+        <button
+          onClick={() => setOriginalData(sampleData)}
+          className="w-full bg-gray-600 text-white font-bold py-2 px-4 rounded-lg hover:bg-gray-700 transition duration-300"
         >
-            Load Sample Data
+          Load Sample Data
         </button>
       </div>
     </div>
@@ -93,3 +131,4 @@ const DataInput: React.FC<DataInputProps> = ({ onDataLoaded }) => {
 };
 
 export default DataInput;
+

--- a/components/ForecastChart.tsx
+++ b/components/ForecastChart.tsx
@@ -10,11 +10,14 @@ interface ForecastChartProps {
 
 const ForecastChart: React.FC<ForecastChartProps> = ({ historicalData, forecastData }) => {
   const chartData = [
-    ...historicalData.map(d => ({ date: d.date, actual: d.sales })),
-    ...forecastData.map(d => ({ 
-      date: d.date, 
-      predicted: d.prediction, 
-      confidence: [d.lowerBound, d.upperBound] 
+    ...historicalData.map(d => ({
+      date: `${d.year}-${String(d.month).padStart(2, '0')}`,
+      actual: d.sales
+    })),
+    ...forecastData.map(d => ({
+      date: d.date,
+      predicted: d.prediction,
+      confidence: [d.lowerBound, d.upperBound]
     }))
   ];
 

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -5,8 +5,8 @@ import { SalesData, Algorithm, AlgorithmParameters, ForecastPoint } from '../typ
 const ai = new GoogleGenAI({ apiKey: process.env.API_KEY as string });
 
 function formatDataToCSV(data: SalesData[]): string {
-  const header = 'date,region,product,sales\n';
-  const rows = data.map(d => `${d.date},${d.region},${d.product},${d.sales}`);
+  const header = 'year,month,sales,country,product\n';
+  const rows = data.map(d => `${d.year},${d.month},${d.sales},${d.country},${d.product}`);
   return header + rows.join('\n');
 }
 
@@ -43,7 +43,8 @@ export async function generateForecast(
   googleTrendsKeywords?: string
 ): Promise<ForecastPoint[]> {
 
-  const lastDate = historicalData[historicalData.length - 1].date;
+  const lastRecord = historicalData[historicalData.length - 1];
+  const lastDate = `${lastRecord.year}-${String(lastRecord.month).padStart(2, '0')}-01`;
   const dataAsCSV = formatDataToCSV(historicalData);
   const paramsString = JSON.stringify(params, null, 2);
 

--- a/types.ts
+++ b/types.ts
@@ -1,9 +1,10 @@
 
 export interface SalesData {
-  date: string;
-  region: string;
-  product: string;
+  year: number;
+  month: number;
   sales: number;
+  country: string;
+  product: string;
 }
 
 export interface ForecastPoint {


### PR DESCRIPTION
## Summary
- Update sales data model to use year, month, sales, country, product
- Parse new CSV layout and add country/product filters in data input
- Adjust chart and forecast service for revised data structure

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b05544cd448328adc2dbdbe1995ec0