### PR TITLE
Ensure forecasts start after last data point

### DIFF
--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -83,12 +83,16 @@ export async function generateForecast(
   });
 
   const responseText = response.text.trim();
-  
+
   try {
     const parsedJson = JSON.parse(responseText);
     // Basic validation
     if (Array.isArray(parsedJson) && parsedJson.length > 0 && 'prediction' in parsedJson[0]) {
-      return parsedJson as ForecastPoint[];
+      const lastDateObj = new Date(lastRecord.year, lastRecord.month - 1, 1);
+      const filtered = (parsedJson as ForecastPoint[]).filter(
+        point => new Date(point.date) > lastDateObj
+      );
+      return filtered;
     }
     throw new Error('Invalid JSON structure');
   } catch (error) {


### PR DESCRIPTION
## Summary
- filter forecast output so predictions start after the final month in the input data

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b05da957948328bbabf440e5c0ed46