### PR TITLE
feat: update header and remove dark mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+

--- a/App.tsx
+++ b/App.tsx
@@ -64,7 +64,7 @@ export default function App() {
   };
 
   return (
-    <div className="min-h-screen bg-dark-bg font-sans">
+    <div className="min-h-screen bg-gray-50 font-sans">
       <Header />
       <main className="container mx-auto p-4 md:p-8">
         <div className="grid grid-cols-1 lg:grid-cols-12 gap-8">
@@ -86,21 +86,21 @@ export default function App() {
             >
               {isLoading ? <Spinner /> : 'Run Forecast'}
             </button>
-            {error && <p className="text-red-400 text-center mt-2">{error}</p>}
+            {error && <p className="text-red-500 text-center mt-2">{error}</p>}
           </div>
 
           <div className="lg:col-span-8">
-            <div className="bg-dark-surface rounded-xl shadow-lg p-6">
-              <h2 className="text-2xl font-bold mb-4 text-dark-text-primary">Forecast Visualization</h2>
+            <div className="bg-white rounded-xl shadow-lg p-6">
+              <h2 className="text-2xl font-bold mb-4 text-gray-900">Forecast Visualization</h2>
               {isLoading && (
                  <div className="flex flex-col items-center justify-center h-96">
                     <Spinner />
-                    <p className="mt-4 text-dark-text-secondary">Generating your 24-month forecast...</p>
+                    <p className="mt-4 text-gray-600">Generating your 24-month forecast...</p>
                  </div>
               )}
               {!isLoading && forecastData.length === 0 && (
-                <div className="flex items-center justify-center h-96 bg-gray-800 rounded-lg">
-                  <p className="text-dark-text-secondary">Your forecast chart will appear here.</p>
+                <div className="flex items-center justify-center h-96 bg-gray-100 rounded-lg">
+                  <p className="text-gray-600">Your forecast chart will appear here.</p>
                 </div>
               )}
               {!isLoading && forecastData.length > 0 && (

--- a/components/ControlPanel.tsx
+++ b/components/ControlPanel.tsx
@@ -24,30 +24,30 @@ const ControlPanel: React.FC<ControlPanelProps> = ({
   const [showParams, setShowParams] = useState(false);
 
   return (
-    <div className="bg-dark-surface rounded-xl shadow-lg p-6 space-y-6">
+    <div className="bg-white rounded-xl shadow-lg p-6 space-y-6">
       <div>
-        <h2 className="text-xl font-bold mb-4 text-dark-text-primary">2. Configure Forecast</h2>
-        <label htmlFor="algorithm-select" className="block text-sm font-medium text-dark-text-secondary mb-1">
+        <h2 className="text-xl font-bold mb-4 text-gray-900">2. Configure Forecast</h2>
+        <label htmlFor="algorithm-select" className="block text-sm font-medium text-gray-700 mb-1">
           Forecasting Algorithm
         </label>
         <select
           id="algorithm-select"
           value={selectedAlgorithm.name}
           onChange={(e) => onAlgorithmChange(e.target.value)}
-          className="w-full bg-gray-700 border border-gray-600 rounded-lg p-2.5 text-dark-text-primary focus:ring-brand-primary focus:border-brand-primary"
+          className="w-full bg-white border border-gray-300 rounded-lg p-2.5 text-gray-900 focus:ring-brand-primary focus:border-brand-primary"
         >
           {algorithms.map(algo => (
             <option key={algo.name} value={algo.name}>{algo.name}</option>
           ))}
         </select>
-        <p className="text-xs text-gray-400 mt-2">{selectedAlgorithm.description}</p>
+        <p className="text-xs text-gray-500 mt-2">{selectedAlgorithm.description}</p>
       </div>
 
       <div>
         <button
           type="button"
           onClick={() => setShowParams(prev => !prev)}
-          className="flex justify-between items-center w-full text-lg font-semibold mb-3 text-dark-text-secondary"
+          className="flex justify-between items-center w-full text-lg font-semibold mb-3 text-gray-700"
         >
           <span>Algorithm Parameters</span>
           <span>{showParams ? '-' : '+'}</span>
@@ -56,7 +56,7 @@ const ControlPanel: React.FC<ControlPanelProps> = ({
           <div className="space-y-4">
             {selectedAlgorithm.parameters.map(param => (
               <div key={param.id}>
-                <label htmlFor={param.id} className="block text-sm font-medium text-dark-text-primary mb-1 flex justify-between">
+                <label htmlFor={param.id} className="block text-sm font-medium text-gray-900 mb-1 flex justify-between">
                   <span>{param.name}</span>
                   <span>{params[param.id]}</span>
                 </label>
@@ -69,7 +69,7 @@ const ControlPanel: React.FC<ControlPanelProps> = ({
                     step={param.step}
                     value={params[param.id] as number}
                     onChange={(e) => onParamsChange(param.id, parseFloat(e.target.value))}
-                    className="w-full h-2 bg-gray-700 rounded-lg appearance-none cursor-pointer"
+                    className="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer"
                   />
                 )}
                 {param.type === 'select' && (
@@ -77,12 +77,12 @@ const ControlPanel: React.FC<ControlPanelProps> = ({
                     id={param.id}
                     value={params[param.id] as string}
                     onChange={(e) => onParamsChange(param.id, e.target.value)}
-                    className="w-full bg-gray-700 border border-gray-600 rounded-lg p-2.5 text-dark-text-primary focus:ring-brand-primary focus:border-brand-primary"
+                    className="w-full bg-white border border-gray-300 rounded-lg p-2.5 text-gray-900 focus:ring-brand-primary focus:border-brand-primary"
                   >
                     {param.options?.map(opt => <option key={opt} value={opt}>{opt}</option>)}
                   </select>
                 )}
-                <p className="text-xs text-gray-400 mt-1">{param.description}</p>
+                <p className="text-xs text-gray-500 mt-1">{param.description}</p>
               </div>
             ))}
           </div>
@@ -90,8 +90,8 @@ const ControlPanel: React.FC<ControlPanelProps> = ({
       </div>
 
        <div>
-        <h3 className="text-lg font-semibold mb-3 text-dark-text-secondary">Google Trends (Optional)</h3>
-         <label htmlFor="google-trends" className="block text-sm font-medium text-dark-text-primary mb-1">
+        <h3 className="text-lg font-semibold mb-3 text-gray-700">Google Trends (Optional)</h3>
+         <label htmlFor="google-trends" className="block text-sm font-medium text-gray-900 mb-1">
            Keywords
         </label>
         <input
@@ -100,9 +100,9 @@ const ControlPanel: React.FC<ControlPanelProps> = ({
           value={googleTrendsKeywords}
           onChange={(e) => onGoogleTrendsKeywordsChange(e.target.value)}
           placeholder="e.g., sustainable products, AI tools"
-          className="w-full bg-gray-700 border border-gray-600 rounded-lg p-2.5 text-dark-text-primary focus:ring-brand-primary focus:border-brand-primary"
+          className="w-full bg-white border border-gray-300 rounded-lg p-2.5 text-gray-900 focus:ring-brand-primary focus:border-brand-primary"
         />
-        <p className="text-xs text-gray-400 mt-1">Add keywords to have the AI consider their trend impact.</p>
+        <p className="text-xs text-gray-500 mt-1">Add keywords to have the AI consider their trend impact.</p>
       </div>
     </div>
   );

--- a/components/DataInput.tsx
+++ b/components/DataInput.tsx
@@ -78,28 +78,28 @@ const DataInput: React.FC<DataInputProps> = ({ onDataLoaded }) => {
   ];
 
   return (
-    <div className="bg-dark-surface rounded-xl shadow-lg p-6">
-      <h2 className="text-xl font-bold mb-4 text-dark-text-primary">1. Input Your Data</h2>
+    <div className="bg-white rounded-xl shadow-lg p-6">
+      <h2 className="text-xl font-bold mb-4 text-gray-900">1. Input Your Data</h2>
 
       {originalData.length > 0 && (
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-4">
           <div>
-            <label className="block text-sm font-medium text-dark-text-secondary mb-1">Country</label>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Country</label>
             <select
               value={countryFilter}
               onChange={(e) => setCountryFilter(e.target.value)}
-              className="w-full bg-gray-700 border border-gray-600 rounded-lg p-2.5 text-dark-text-primary focus:ring-brand-primary focus:border-brand-primary"
+              className="w-full bg-white border border-gray-300 rounded-lg p-2.5 text-gray-900 focus:ring-brand-primary focus:border-brand-primary"
             >
               <option value="All">All Countries</option>
               {countries.map(c => <option key={c} value={c}>{c}</option>)}
             </select>
           </div>
           <div>
-            <label className="block text-sm font-medium text-dark-text-secondary mb-1">Product</label>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Product</label>
             <select
               value={productFilter}
               onChange={(e) => setProductFilter(e.target.value)}
-              className="w-full bg-gray-700 border border-gray-600 rounded-lg p-2.5 text-dark-text-primary focus:ring-brand-primary focus:border-brand-primary"
+              className="w-full bg-white border border-gray-300 rounded-lg p-2.5 text-gray-900 focus:ring-brand-primary focus:border-brand-primary"
             >
               <option value="All">All Products</option>
               {products.map(p => <option key={p} value={p}>{p}</option>)}
@@ -109,19 +109,19 @@ const DataInput: React.FC<DataInputProps> = ({ onDataLoaded }) => {
       )}
 
       <div>
-        <h3 className="text-lg font-semibold mb-2 text-dark-text-secondary">Upload CSV</h3>
-        <p className="text-sm text-gray-400 mb-3">Must contain columns: year, month, sales, country, product.</p>
+        <h3 className="text-lg font-semibold mb-2 text-gray-700">Upload CSV</h3>
+        <p className="text-sm text-gray-500 mb-3">Must contain columns: year, month, sales, country, product.</p>
         <input
           type="file"
           accept=".csv"
           onChange={handleFileChange}
-          className="block w-full text-sm text-gray-400 file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:font-semibold file:bg-brand-secondary file:text-brand-primary hover:file:bg-blue-200"
+          className="block w-full text-sm text-gray-700 file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:font-semibold file:bg-brand-secondary file:text-brand-primary hover:file:bg-blue-200"
         />
-        {error && <p className="text-red-400 text-sm mt-2">{error}</p>}
+        {error && <p className="text-red-500 text-sm mt-2">{error}</p>}
         <p className="text-center my-4 text-gray-500">OR</p>
         <button
           onClick={() => setOriginalData(sampleData)}
-          className="w-full bg-gray-600 text-white font-bold py-2 px-4 rounded-lg hover:bg-gray-700 transition duration-300"
+          className="w-full bg-blue-600 text-white font-bold py-2 px-4 rounded-lg hover:bg-blue-700 transition duration-300"
         >
           Load Sample Data
         </button>

--- a/components/ForecastChart.tsx
+++ b/components/ForecastChart.tsx
@@ -25,14 +25,14 @@ const ForecastChart: React.FC<ForecastChartProps> = ({ historicalData, forecastD
     <div style={{ width: '100%', height: 400 }}>
       <ResponsiveContainer>
         <LineChart data={chartData} margin={{ top: 5, right: 30, left: 20, bottom: 5 }}>
-          <CartesianGrid strokeDasharray="3 3" stroke="#444" />
-          <XAxis dataKey="date" stroke="#969ba1" tick={{ fontSize: 12 }} />
-          <YAxis stroke="#969ba1" tick={{ fontSize: 12 }} />
-          <Tooltip 
-            contentStyle={{ backgroundColor: '#202124', border: '1px solid #444' }}
-            labelStyle={{ color: '#e8eaed' }}
+          <CartesianGrid strokeDasharray="3 3" stroke="#ccc" />
+          <XAxis dataKey="date" stroke="#666" tick={{ fontSize: 12 }} />
+          <YAxis stroke="#666" tick={{ fontSize: 12 }} />
+          <Tooltip
+            contentStyle={{ backgroundColor: '#ffffff', border: '1px solid #ddd' }}
+            labelStyle={{ color: '#000000' }}
           />
-          <Legend wrapperStyle={{color: '#e8eaed'}} />
+          <Legend wrapperStyle={{color: '#000000'}} />
           <Line type="monotone" dataKey="actual" stroke="#1a73e8" strokeWidth={2} dot={false} name="Historical Sales" />
           <Line type="monotone" dataKey="predicted" stroke="#34a853" strokeWidth={2} strokeDasharray="5 5" dot={false} name="Forecasted Sales" />
           <Area type="monotone" dataKey="confidence" stroke={false} fill="#34a853" fillOpacity={0.2} name="Confidence Interval" />

--- a/components/ForecastTable.tsx
+++ b/components/ForecastTable.tsx
@@ -30,15 +30,15 @@ const ForecastTable: React.FC<ForecastTableProps> = ({ data }) => {
   return (
     <div>
       <div className="flex justify-between items-center mb-4">
-        <h3 className="text-xl font-bold text-dark-text-primary">Forecast Data</h3>
-        <button onClick={downloadCSV} className="bg-gray-600 text-white font-semibold py-2 px-4 rounded-lg hover:bg-gray-700 transition duration-300 text-sm flex items-center">
+        <h3 className="text-xl font-bold text-gray-900">Forecast Data</h3>
+        <button onClick={downloadCSV} className="bg-blue-600 text-white font-semibold py-2 px-4 rounded-lg hover:bg-blue-700 transition duration-300 text-sm flex items-center">
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="mr-2"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" x2="12" y1="15" y2="3"/></svg>
             Download CSV
         </button>
       </div>
-      <div className="max-h-80 overflow-y-auto rounded-lg border border-gray-700">
-        <table className="w-full text-sm text-left text-gray-400">
-          <thead className="text-xs text-gray-300 uppercase bg-gray-700 sticky top-0">
+      <div className="max-h-80 overflow-y-auto rounded-lg border border-gray-200">
+        <table className="w-full text-sm text-left text-gray-700">
+          <thead className="text-xs text-gray-700 uppercase bg-gray-100 sticky top-0">
             <tr>
               <th scope="col" className="px-6 py-3">Date</th>
               <th scope="col" className="px-6 py-3">Prediction</th>
@@ -48,8 +48,8 @@ const ForecastTable: React.FC<ForecastTableProps> = ({ data }) => {
           </thead>
           <tbody>
             {data.map((row) => (
-              <tr key={row.date} className="bg-dark-surface border-b border-gray-700 hover:bg-gray-800">
-                <td className="px-6 py-4 font-medium text-gray-200">{row.date}</td>
+              <tr key={row.date} className="bg-white border-b border-gray-200 hover:bg-gray-50">
+                <td className="px-6 py-4 font-medium text-gray-900">{row.date}</td>
                 <td className="px-6 py-4">{row.prediction.toFixed(2)}</td>
                 <td className="px-6 py-4">{row.lowerBound.toFixed(2)}</td>
                 <td className="px-6 py-4">{row.upperBound.toFixed(2)}</td>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -3,13 +3,13 @@ import React from 'react';
 
 const Header: React.FC = () => {
   return (
-    <header className="bg-dark-surface p-4 shadow-md">
+    <header className="bg-white py-2 px-4 shadow-md">
       <div className="container mx-auto flex items-center">
         <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-brand-primary">
             <path d="M3 3v18h18"/><path d="m19 9-5 5-4-4-3 3"/>
         </svg>
-        <h1 className="text-2xl font-bold ml-3 text-dark-text-primary">
-          Sales Forecast <span className="text-brand-primary">AI</span>
+        <h1 className="text-2xl font-bold ml-3 text-gray-900">
+          Seegene 매출 예측 시뮬레이터
         </h1>
       </div>
     </header>

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Sales Forecast AI</title>
+    <title>Seegene 매출 예측 시뮬레이터</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
       tailwind.config = {
@@ -13,11 +13,7 @@
           extend: {
             colors: {
               'brand-primary': '#1a73e8',
-              'brand-secondary': '#e8f0fe',
-              'dark-bg': '#202124',
-              'dark-surface': '#303134',
-              'dark-text-primary': '#e8eaed',
-              'dark-text-secondary': '#969ba1',
+              'brand-secondary': '#e8f0fe'
             },
           },
         },
@@ -36,7 +32,7 @@
 </script>
 <link rel="stylesheet" href="/index.css">
 </head>
-  <body class="bg-dark-bg text-dark-text-primary">
+  <body class="bg-white text-gray-900">
     <div id="root"></div>
     <script type="module" src="/index.tsx"></script>
   </body>


### PR DESCRIPTION
## Summary
- set application title to "Seegene 매출 예측 시뮬레이터"
- drop dark theme and adopt light styling across components
- shrink header height for a more compact layout

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b0623448d88328a848a817c9124ea5